### PR TITLE
Fix wrong escape param

### DIFF
--- a/views/templates/hook/product-comments-list.tpl
+++ b/views/templates/hook/product-comments-list.tpl
@@ -45,7 +45,7 @@
        data-list-comments-url="{$list_comments_url nofilter}"
        data-update-comment-usefulness-url="{$update_comment_usefulness_url nofilter}"
        data-report-comment-url="{$report_comment_url nofilter}"
-       data-comment-item-prototype="{$comment_prototype|escape:'html_attr'}">
+       data-comment-item-prototype="{$comment_prototype|escape:'html'}">
   </div>
 </div>
 <div class="row">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `html_attr` is not a valid param for the `escape` function in smarty. The right param is `html`.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | after doing `composer update smarty/smarty`, in the FO try to access a product page, you'll have an exception. Update the `productcomments` module with this PR, the exception should not happen anymore

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
